### PR TITLE
Add social metadata and icons

### DIFF
--- a/clusterhub.html
+++ b/clusterhub.html
@@ -5,6 +5,14 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <base target="_self"/>
+<meta property="og:title" content="Cluster Hub | Innovación Cultural y Tecnológica"/>
+<meta property="og:description" content="Plataforma de proyectos culturales y tecnológicos como Kompira Maru y Colectivo Ebra."/>
+<meta property="og:image" content="/assets/img/og/home.jpg"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"/>
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"/>
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
+<link rel="manifest" href="/site.webmanifest"/>
 <title>Cluster Hub | Innovación Cultural y Tecnológica</title>
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://cdn.jsdelivr.net/npm/@preline/preline@2.0.0/dist/preline.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta property="og:title" content="CLVSTER HVB | Inicio">
+  <meta property="og:description" content="Portal de entrada a CLVSTER HVB, red de innovación cultural y tecnológica.">
+  <meta property="og:image" content="/assets/img/og/home.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="manifest" href="/site.webmanifest">
   <title>CLVSTER HVB | Inicio</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata to home and project pages
- link favicon, touch icon, and web manifest for consistent branding

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b676e92c83268385364d7eff0925