### PR TITLE
Add responsive picture elements for project pages

### DIFF
--- a/clusterhub.html
+++ b/clusterhub.html
@@ -281,7 +281,7 @@
 <picture>
   <source srcset="assets/img/talento/jesus-rios/profile.avif 1x, assets/img/talento/jesus-rios/profile@2x.avif 2x" type="image/avif" sizes="96px" />
   <source srcset="assets/img/talento/jesus-rios/profile.webp 1x, assets/img/talento/jesus-rios/profile@2x.webp 2x" type="image/webp" sizes="96px" />
-  <img src="assets/img/talento/jesus-rios/profile.jpg" srcset="assets/img/talento/jesus-rios/profile.jpg 1x, assets/img/talento/jesus-rios/profile@2x.jpg 2x" width="96" height="96" alt="Fundadora" class="w-full h-full object-cover" loading="lazy" decoding="async" />
+  <img src="assets/img/talento/jesus-rios/profile.jpg" srcset="assets/img/talento/jesus-rios/profile.jpg 1x, assets/img/talento/jesus-rios/profile@2x.jpg 2x" width="96" height="96" alt="Jesús María Ríos Trujillo" class="w-full h-full object-cover" loading="lazy" decoding="async" />
 </picture>
 </div>
 <h4 class="font-bold mb-1">Jesús María Ríos Trujillo</h4>
@@ -296,7 +296,7 @@
 <picture>
   <source srcset="assets/img/talento/heberto-jimenez/profile.avif 1x, assets/img/talento/heberto-jimenez/profile@2x.avif 2x" type="image/avif" sizes="96px" />
   <source srcset="assets/img/talento/heberto-jimenez/profile.webp 1x, assets/img/talento/heberto-jimenez/profile@2x.webp 2x" type="image/webp" sizes="96px" />
-  <img src="assets/img/talento/heberto-jimenez/profile.jpg" srcset="assets/img/talento/heberto-jimenez/profile.jpg 1x, assets/img/talento/heberto-jimenez/profile@2x.jpg 2x" width="96" height="96" alt="Co-fundador" class="w-full h-full object-cover" loading="lazy" decoding="async" />
+  <img src="assets/img/talento/heberto-jimenez/profile.jpg" srcset="assets/img/talento/heberto-jimenez/profile.jpg 1x, assets/img/talento/heberto-jimenez/profile@2x.jpg 2x" width="96" height="96" alt="Heberto Jimenez Estupiñan" class="w-full h-full object-cover" loading="lazy" decoding="async" />
 </picture>
 </div>
 <h4 class="font-bold mb-1">Heberto Jimenez Estupiñan</h4>
@@ -309,7 +309,7 @@
 <div class="bg-gray-800 p-6 rounded-xl shadow-md text-center card-hover glow-border">
 <div class="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
 <picture>
-  <img alt="Co-fundadora" class="w-full h-full object-cover" src="https://randomuser.me/api/portraits/women/68.jpg" width="96" height="96" loading="lazy" decoding="async" />
+  <img alt="Ana Gómez" class="w-full h-full object-cover" src="https://randomuser.me/api/portraits/women/68.jpg" width="96" height="96" loading="lazy" decoding="async" />
 </picture>
 </div>
 <h4 class="font-bold mb-1">Ana Gómez</h4>
@@ -322,7 +322,7 @@
 <div class="bg-gray-800 p-6 rounded-xl shadow-md text-center card-hover glow-border">
 <div class="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
 <picture>
-  <img alt="Co-fundador" class="w-full h-full object-cover" src="https://randomuser.me/api/portraits/men/75.jpg" width="96" height="96" loading="lazy" decoding="async" />
+  <img alt="José Martínez" class="w-full h-full object-cover" src="https://randomuser.me/api/portraits/men/75.jpg" width="96" height="96" loading="lazy" decoding="async" />
 </picture>
 </div>
 <h4 class="font-bold mb-1">José Martínez</h4>

--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
     <picture>
       <source srcset="assets/img/home/hero.avif 1x, assets/img/home/hero@2x.avif 2x" type="image/avif" sizes="(max-width: 600px) 100vw, 600px" />
       <source srcset="assets/img/home/hero.webp 1x, assets/img/home/hero@2x.webp 2x" type="image/webp" sizes="(max-width: 600px) 100vw, 600px" />
-      <img src="assets/img/home/hero.jpg" srcset="assets/img/home/hero.jpg 1x, assets/img/home/hero@2x.jpg 2x" width="600" height="400" alt="CLVSTER HVB" class="logo-center" loading="lazy" decoding="async" />
+      <img src="assets/img/home/hero.jpg" srcset="assets/img/home/hero.jpg 1x, assets/img/home/hero@2x.jpg 2x" width="600" height="400" alt="Logotipo de CLVSTER HVB" class="logo-center" loading="lazy" decoding="async" />
     </picture>
     
     <!-- Botón de entrada -->

--- a/proyectos/ebra/index.html
+++ b/proyectos/ebra/index.html
@@ -5,6 +5,11 @@
   <title>Colectivo Ebra</title>
 </head>
 <body>
+  <picture>
+    <source srcset="../../assets/img/proyectos/ebra/hero.avif 1x, ../../assets/img/proyectos/ebra/hero@2x.avif 2x" type="image/avif" sizes="(max-width: 1200px) 100vw, 1200px" />
+    <source srcset="../../assets/img/proyectos/ebra/hero.webp 1x, ../../assets/img/proyectos/ebra/hero@2x.webp 2x" type="image/webp" sizes="(max-width: 1200px) 100vw, 1200px" />
+    <img src="../../assets/img/proyectos/ebra/hero.jpg" srcset="../../assets/img/proyectos/ebra/hero.jpg 1x, ../../assets/img/proyectos/ebra/hero@2x.jpg 2x" width="1200" height="675" alt="Red de Casas de Saberes Ancestrales - Colectivo Ebra" loading="lazy" decoding="async" />
+  </picture>
   <h1>Colectivo Ebra</h1>
   <nav>
     <ul>

--- a/proyectos/kompira-maru/index.html
+++ b/proyectos/kompira-maru/index.html
@@ -5,6 +5,11 @@
   <title>KOMPIRA MARU</title>
 </head>
 <body>
+  <picture>
+    <source srcset="../../assets/img/proyectos/kompira-maru/hero.avif 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.avif 2x" type="image/avif" sizes="(max-width: 1200px) 100vw, 1200px" />
+    <source srcset="../../assets/img/proyectos/kompira-maru/hero.webp 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.webp 2x" type="image/webp" sizes="(max-width: 1200px) 100vw, 1200px" />
+    <img src="../../assets/img/proyectos/kompira-maru/hero.jpg" srcset="../../assets/img/proyectos/kompira-maru/hero.jpg 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.jpg 2x" width="1200" height="675" alt="Festival Kompira Maru" loading="lazy" decoding="async" />
+  </picture>
   <h1>KOMPIRA MARU</h1>
   <nav>
     <ul>


### PR DESCRIPTION
## Summary
- use `<picture>` with AVIF/WebP sources for hero images on Kompira Maru and Colectivo Ebra pages
- improve hero logo alt text on landing page
- add descriptive alt text for talent avatars in Cluster Hub

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fb14137083268b40bff62ff00ff0