### PR TITLE
Add social metadata to project and portfolio pages

### DIFF
--- a/proyectos/ebra/index.html
+++ b/proyectos/ebra/index.html
@@ -2,6 +2,14 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
+  <meta property="og:title" content="Colectivo Ebra">
+  <meta property="og:description" content="Página del proyecto Colectivo Ebra.">
+  <meta property="og:image" content="/assets/img/og/ebra.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="manifest" href="/site.webmanifest">
   <title>Colectivo Ebra</title>
 </head>
 <body>

--- a/proyectos/ebra/portafolio/index.html
+++ b/proyectos/ebra/portafolio/index.html
@@ -2,6 +2,14 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
+  <meta property="og:title" content="Portafolio Colectivo Ebra">
+  <meta property="og:description" content="Portafolio del Colectivo Ebra.">
+  <meta property="og:image" content="/assets/img/og/ebra.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="manifest" href="/site.webmanifest">
   <title>Portafolio Colectivo Ebra</title>
 </head>
 <body>

--- a/proyectos/kompira-maru/index.html
+++ b/proyectos/kompira-maru/index.html
@@ -2,6 +2,14 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
+  <meta property="og:title" content="KOMPIRA MARU">
+  <meta property="og:description" content="Página del proyecto KOMPIRA MARU.">
+  <meta property="og:image" content="/assets/img/og/kompira-maru.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="manifest" href="/site.webmanifest">
   <title>KOMPIRA MARU</title>
 </head>
 <body>

--- a/proyectos/kompira-maru/portafolio/index.html
+++ b/proyectos/kompira-maru/portafolio/index.html
@@ -2,6 +2,14 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
+  <meta property="og:title" content="Portafolio KOMPIRA MARU">
+  <meta property="og:description" content="Portafolio del proyecto KOMPIRA MARU.">
+  <meta property="og:image" content="/assets/img/og/kompira-maru.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="manifest" href="/site.webmanifest">
   <title>Portafolio KOMPIRA MARU</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata for project and portfolio pages
- include favicon, apple touch icon, and manifest links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fc9f6298832693ec0c294fdd7af7