### PR TITLE
Add scaffolding for new project pages

### DIFF
--- a/proyectos/bacatacartografia/index.html
+++ b/proyectos/bacatacartografia/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Bacatá Cartografía</title>
+</head>
+<body>
+  <h1>Bacatá Cartografía</h1>
+  <nav>
+    <ul>
+      <li><a href="./portafolio/">Portafolio</a></li>
+      <li><a href="../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Descripción breve del proyecto Bacatá Cartografía.</p>
+  <img src="../../assets/img/proyectos/bacatacartografia/hero.jpg" alt="Bacatá Cartografía" />
+</body>
+</html>

--- a/proyectos/bacatacartografia/portafolio/index.html
+++ b/proyectos/bacatacartografia/portafolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Portafolio Bacatá Cartografía</title>
+</head>
+<body>
+  <h1>Portafolio de Bacatá Cartografía</h1>
+  <nav>
+    <ul>
+      <li><a href="../index.html">Inicio de Bacatá Cartografía</a></li>
+      <li><a href="../../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Contenido del portafolio en construcción.</p>
+</body>
+</html>

--- a/proyectos/capitoliointeractivo/index.html
+++ b/proyectos/capitoliointeractivo/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Capitolio Interactivo</title>
+</head>
+<body>
+  <h1>Capitolio Interactivo</h1>
+  <nav>
+    <ul>
+      <li><a href="./portafolio/">Portafolio</a></li>
+      <li><a href="../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Descripción breve del proyecto Capitolio Interactivo.</p>
+  <img src="../../assets/img/proyectos/capitoliointeractivo/hero.jpg" alt="Capitolio Interactivo" />
+</body>
+</html>

--- a/proyectos/capitoliointeractivo/portafolio/index.html
+++ b/proyectos/capitoliointeractivo/portafolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Portafolio Capitolio Interactivo</title>
+</head>
+<body>
+  <h1>Portafolio de Capitolio Interactivo</h1>
+  <nav>
+    <ul>
+      <li><a href="../index.html">Inicio de Capitolio Interactivo</a></li>
+      <li><a href="../../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Contenido del portafolio en construcción.</p>
+</body>
+</html>

--- a/proyectos/concejosdejuventud2021/index.html
+++ b/proyectos/concejosdejuventud2021/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Concejos de Juventud 2021</title>
+</head>
+<body>
+  <h1>Concejos de Juventud 2021</h1>
+  <nav>
+    <ul>
+      <li><a href="./portafolio/">Portafolio</a></li>
+      <li><a href="../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Descripción breve del proyecto Concejos de Juventud 2021.</p>
+  <img src="../../assets/img/proyectos/concejosdejuventud2021/hero.jpg" alt="Concejos de Juventud 2021" />
+</body>
+</html>

--- a/proyectos/concejosdejuventud2021/portafolio/index.html
+++ b/proyectos/concejosdejuventud2021/portafolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Portafolio Concejos de Juventud 2021</title>
+</head>
+<body>
+  <h1>Portafolio de Concejos de Juventud 2021</h1>
+  <nav>
+    <ul>
+      <li><a href="../index.html">Inicio de Concejos de Juventud 2021</a></li>
+      <li><a href="../../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Contenido del portafolio en construcción.</p>
+</body>
+</html>

--- a/proyectos/concejosdejuventud2025/index.html
+++ b/proyectos/concejosdejuventud2025/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Concejos de Juventud 2025</title>
+</head>
+<body>
+  <h1>Concejos de Juventud 2025</h1>
+  <nav>
+    <ul>
+      <li><a href="./portafolio/">Portafolio</a></li>
+      <li><a href="../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Descripción breve del proyecto Concejos de Juventud 2025.</p>
+  <img src="../../assets/img/proyectos/concejosdejuventud2025/hero.jpg" alt="Concejos de Juventud 2025" />
+</body>
+</html>

--- a/proyectos/concejosdejuventud2025/portafolio/index.html
+++ b/proyectos/concejosdejuventud2025/portafolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Portafolio Concejos de Juventud 2025</title>
+</head>
+<body>
+  <h1>Portafolio de Concejos de Juventud 2025</h1>
+  <nav>
+    <ul>
+      <li><a href="../index.html">Inicio de Concejos de Juventud 2025</a></li>
+      <li><a href="../../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Contenido del portafolio en construcción.</p>
+</body>
+</html>

--- a/proyectos/pythonpaquetes/index.html
+++ b/proyectos/pythonpaquetes/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Python Paquetes</title>
+</head>
+<body>
+  <h1>Python Paquetes</h1>
+  <nav>
+    <ul>
+      <li><a href="./portafolio/">Portafolio</a></li>
+      <li><a href="../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Descripción breve del proyecto Python Paquetes.</p>
+  <img src="../../assets/img/proyectos/pythonpaquetes/hero.jpg" alt="Python Paquetes" />
+</body>
+</html>

--- a/proyectos/pythonpaquetes/portafolio/index.html
+++ b/proyectos/pythonpaquetes/portafolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Portafolio Python Paquetes</title>
+</head>
+<body>
+  <h1>Portafolio de Python Paquetes</h1>
+  <nav>
+    <ul>
+      <li><a href="../index.html">Inicio de Python Paquetes</a></li>
+      <li><a href="../../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Contenido del portafolio en construcción.</p>
+</body>
+</html>

--- a/proyectos/recicladoresbogota/index.html
+++ b/proyectos/recicladoresbogota/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Recicladores Bogotá</title>
+</head>
+<body>
+  <h1>Recicladores Bogotá</h1>
+  <nav>
+    <ul>
+      <li><a href="./portafolio/">Portafolio</a></li>
+      <li><a href="../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Descripción breve del proyecto Recicladores Bogotá.</p>
+  <img src="../../assets/img/proyectos/recicladoresbogota/hero.jpg" alt="Recicladores Bogotá" />
+</body>
+</html>

--- a/proyectos/recicladoresbogota/portafolio/index.html
+++ b/proyectos/recicladoresbogota/portafolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Portafolio Recicladores Bogotá</title>
+</head>
+<body>
+  <h1>Portafolio de Recicladores Bogotá</h1>
+  <nav>
+    <ul>
+      <li><a href="../index.html">Inicio de Recicladores Bogotá</a></li>
+      <li><a href="../../../clusterhub.html">Volver a CLVSTER HVB</a></li>
+    </ul>
+  </nav>
+  <p>Contenido del portafolio en construcción.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold projects: recicladoresbogota, pythonpaquetes, bacatacartografia, capitoliointeractivo, concejosdejuventud2025, concejosdejuventud2021
- add generic landing and portfolio pages referencing their asset folders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5011015b0832687818c8246ff3eb5