### PR TITLE
Fix hero images for Kompira Maru and Ebra pages

### DIFF
--- a/proyectos/ebra/index.html
+++ b/proyectos/ebra/index.html
@@ -10,14 +10,12 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="preload" as="image" href="../../assets/img/proyectos/ebra/hero.jpg" imagesrcset="../../assets/img/proyectos/ebra/hero.jpg 1x, ../../assets/img/proyectos/ebra/hero@2x.jpg 2x" imagesizes="(max-width: 1200px) 100vw, 1200px">
+  <link rel="preload" as="image" href="../../proyecto_ebra.png">
   <title>Colectivo Ebra</title>
 </head>
 <body>
   <picture>
-    <source srcset="../../assets/img/proyectos/ebra/hero.avif 1x, ../../assets/img/proyectos/ebra/hero@2x.avif 2x" type="image/avif" sizes="(max-width: 1200px) 100vw, 1200px" />
-    <source srcset="../../assets/img/proyectos/ebra/hero.webp 1x, ../../assets/img/proyectos/ebra/hero@2x.webp 2x" type="image/webp" sizes="(max-width: 1200px) 100vw, 1200px" />
-    <img src="../../assets/img/proyectos/ebra/hero.jpg" srcset="../../assets/img/proyectos/ebra/hero.jpg 1x, ../../assets/img/proyectos/ebra/hero@2x.jpg 2x" width="1200" height="675" alt="Red de Casas de Saberes Ancestrales - Colectivo Ebra" loading="lazy" decoding="async" />
+    <img src="../../proyecto_ebra.png" width="1200" height="675" alt="Red de Casas de Saberes Ancestrales - Colectivo Ebra" loading="lazy" decoding="async" />
   </picture>
   <h1>Colectivo Ebra</h1>
   <nav>

--- a/proyectos/kompira-maru/index.html
+++ b/proyectos/kompira-maru/index.html
@@ -10,14 +10,12 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="preload" as="image" href="../../assets/img/proyectos/kompira-maru/hero.jpg" imagesrcset="../../assets/img/proyectos/kompira-maru/hero.jpg 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.jpg 2x" imagesizes="(max-width: 1200px) 100vw, 1200px">
+  <link rel="preload" as="image" href="../../kompira.png">
   <title>KOMPIRA MARU</title>
 </head>
 <body>
   <picture>
-    <source srcset="../../assets/img/proyectos/kompira-maru/hero.avif 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.avif 2x" type="image/avif" sizes="(max-width: 1200px) 100vw, 1200px" />
-    <source srcset="../../assets/img/proyectos/kompira-maru/hero.webp 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.webp 2x" type="image/webp" sizes="(max-width: 1200px) 100vw, 1200px" />
-    <img src="../../assets/img/proyectos/kompira-maru/hero.jpg" srcset="../../assets/img/proyectos/kompira-maru/hero.jpg 1x, ../../assets/img/proyectos/kompira-maru/hero@2x.jpg 2x" width="1200" height="675" alt="Festival Kompira Maru" loading="lazy" decoding="async" />
+    <img src="../../kompira.png" width="1200" height="675" alt="Festival Kompira Maru" loading="lazy" decoding="async" />
   </picture>
   <h1>KOMPIRA MARU</h1>
   <nav>


### PR DESCRIPTION
## Summary
- replace the Kompira Maru hero preload and picture sources with the actual PNG asset
- update the Colectivo Ebra hero preload and image source to the existing PNG file

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68cddb42ef8083269433c21fb99c1d1a